### PR TITLE
Unpin versions and swap model file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,12 +16,12 @@ maintainers = [
 dependencies = [
   "click",
   "matplotlib",
-  "numpy<2",
+  "numpy",
   "pandas",
   "pyproj",
   "rasterio",
   "requests",
-  "scikit-learn==1.3.0",
+  "scikit-learn",
   "scipy",
 ]
 dynamic = ["version"]

--- a/uvdat_flood_sim/data/downscaling_model.pkl
+++ b/uvdat_flood_sim/data/downscaling_model.pkl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f3d4d2dad103b9e0795d33d3dac93452a5d8fccb8683ca4b48e0496ba20f327b
-size 75313340
+oid sha256:5565ca4a5e8ca4136a065c71bdbf29b7eb175d458bbb314b0a927170dc6f4d03
+size 75313673


### PR DESCRIPTION
This PR allows uvdat flood-sim to install with new versions of numpy and scikit-learn and complete the simulation correctly.